### PR TITLE
Added Apache Avro encoding/decoding helpers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+### 0.2.0
+
+* Added the `Rimless.encode` (`.avro_encode`) and `Rimless.decode`
+  (`.avro_decode`) helpers/shortcuts to simplify the interaction with the
+  Apache Avro library
+  * The `.encode` method automatically performs input data sanitation and
+    supports deep relative (to the local namespace) schema resolution. This
+    allows you to access deeply located schemes relative by just providing a
+    leading period (eg. `.deep.a.b.c` becomes
+    `development.your_app.deep.a.b.c`)
+* The `.message`, '.sync_message', '.async_message' helpers now make use of the
+  new `.encode` functionality which adds transparent data sanitation and schema
+  name features
+* At the `test` environment the compiled Avro schemas output path is not
+  deleted anymore, instead the compiled schemas are overwritten. This may keep
+  dead schemas, but it allows parallel test execution without flaws. The removal
+  of the compiled schema directory caused previously file read errors when a
+  parallel process started a recompilation.
+
 ### 0.1.4
 
 * Reconfigure (reset) the AvroTurf instance on tests to avoid caching issues

--- a/lib/rimless/avro_utils.rb
+++ b/lib/rimless/avro_utils.rb
@@ -61,7 +61,12 @@ module Rimless
 
     # Clear previous compiled Avro schema files to provide a clean rebuild.
     def clear
-      FileUtils.rm_rf(output_path)
+      # In a test environment, especially with parallel test execution the
+      # recompiling of Avro schemas is error prone due to the deletion of the
+      # configuration (output) directory. This leads to random failures due to
+      # file read calls to temporary not existing files. So we just keep the
+      # files and just overwrite them in place while testing.
+      FileUtils.rm_rf(output_path) unless Rimless.env.test?
       FileUtils.mkdir_p(output_path)
     end
 

--- a/lib/rimless/dependencies.rb
+++ b/lib/rimless/dependencies.rb
@@ -55,14 +55,14 @@ module Rimless
 
         # Setup a global available Apache Avro decoder/encoder with support for
         # the Confluent Schema Registry, but first create a helper instance
-        avro_utils = Rimless::AvroUtils.new
+        Rimless.avro_utils = Rimless::AvroUtils.new
         # Compile our Avro schema templates to ready-to-consume Avro schemas
-        avro_utils.recompile_schemas
+        Rimless.avro_utils.recompile_schemas
         # Register a global Avro messaging instance
         Rimless.avro = AvroTurf::Messaging.new(
           logger: Rimless.logger,
-          namespace: avro_utils.namespace,
-          schemas_path: avro_utils.output_path,
+          namespace: Rimless.avro_utils.namespace,
+          schemas_path: Rimless.avro_utils.output_path,
           registry_url: Rimless.configuration.schema_registry_url
         )
       end

--- a/lib/rimless/kafka_helpers.rb
+++ b/lib/rimless/kafka_helpers.rb
@@ -50,7 +50,7 @@ module Rimless
       # @param topic [String, Symbol, Hash{Symbol => Mixed}] the destination
       #   Apache Kafka topic
       def sync_message(data:, schema:, topic:, **args)
-        encoded = Rimless.avro.encode(data, schema_name: schema.to_s)
+        encoded = Rimless.encode(data, schema: schema)
         sync_raw_message(data: encoded, topic: topic, **args)
       end
       alias_method :message, :sync_message
@@ -66,7 +66,7 @@ module Rimless
       # @param topic [String, Symbol, Hash{Symbol => Mixed}] the destination
       #   Apache Kafka topic
       def async_message(data:, schema:, topic:, **args)
-        encoded = Rimless.avro.encode(data, schema_name: schema.to_s)
+        encoded = Rimless.encode(data, schema: schema)
         async_raw_message(data: encoded, topic: topic, **args)
       end
 

--- a/lib/rimless/rspec/helpers.rb
+++ b/lib/rimless/rspec/helpers.rb
@@ -8,9 +8,10 @@ module Rimless
       # A simple helper to parse a blob of Apache Avro data.
       #
       # @param data [String] the Apache Avro blob
+      # @param opts [Hash{Symbol => Mixed}] additional options
       # @return [Hash{String => Mixed}] the parsed payload
-      def avro_parse(data)
-        Rimless.avro.decode(data)
+      def avro_parse(data, **opts)
+        Rimless.avro_decode(data, **opts)
       end
     end
   end

--- a/spec/fixtures/files/avro_schemas/test_app/deep/schema.avsc.erb
+++ b/spec/fixtures/files/avro_schemas/test_app/deep/schema.avsc.erb
@@ -1,0 +1,11 @@
+{
+  "name": "schema",
+  "namespace": "<%= namespace %>.deep",
+  "type": "record",
+  "fields": [
+    {
+      "name": "name",
+      "type": "string"
+    }
+  ]
+}

--- a/spec/rimless/avro_utils_spec.rb
+++ b/spec/rimless/avro_utils_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe Rimless::AvroUtils do
     let(:file) { instance.output_path.join('test', 'test.file') }
 
     before do
+      Rimless.configuration.env = 'development'
       FileUtils.mkdir_p(File.dirname(file))
       File.write(file, 'test')
     end
@@ -99,7 +100,14 @@ RSpec.describe Rimless::AvroUtils do
   end
 
   describe '#render_file' do
-    before { instance.clear }
+    let(:dest) do
+      instance.output_path.join('development', 'test_app', 'test.avsc').to_s
+    end
+
+    before do
+      Rimless.configuration.env = 'development'
+      instance.clear
+    end
 
     it 'creates the desired output file' do
       expect { instance.render_file(src) }.to \
@@ -109,7 +117,7 @@ RSpec.describe Rimless::AvroUtils do
     it 'replaces the ERB variables' do
       instance.render_file(src)
       expect(YAML.load_file(dest)).to \
-        include('namespace' => 'test.test_app')
+        include('namespace' => 'development.test_app')
     end
 
     it 'checks for correct JSON' do

--- a/spec/rimless/dependencies_spec.rb
+++ b/spec/rimless/dependencies_spec.rb
@@ -56,6 +56,12 @@ RSpec.describe Rimless::Dependencies do
     end
     # rubocop:enable RSpec/AnyInstance
 
+    it 'sets the global AvroUtils handle' do
+      Rimless.avro_utils = nil
+      expect { described_class.configure_avro_turf }.to \
+        change(Rimless, :avro_utils).from(nil).to(Rimless::AvroUtils)
+    end
+
     it 'sets the global Apache Avro handle' do
       Rimless.avro = nil
       expect { described_class.configure_avro_turf }.to \

--- a/spec/rimless/rspec/helpers_spec.rb
+++ b/spec/rimless/rspec/helpers_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Rimless::RSpec::Helpers do
     let(:encoded) { Rimless.avro.encode(avro_data, schema_name: 'test') }
 
     it 'decodes a binary Apache Avro message' do
-      expect(avro_parse(encoded)).to be_eql(avro_data)
+      expect(avro_parse(encoded)).to be_eql(avro_data_symbol_keys)
     end
   end
 end

--- a/spec/support/avro_data.rb
+++ b/spec/support/avro_data.rb
@@ -3,12 +3,16 @@
 # Return a datum which is compatible to the test schema.
 #
 # @param deep [Hash{Symbol => String}] a different deep hash to embed
+# @return [Hash{Symbol => Mixed}] the datum
+def avro_data_symbol_keys(deep = nil)
+  deep ||= { test: 'true', fancy: 'data' }
+  { name: 'test', include: { id: 'uuid-v4' }, deep: deep }
+end
+
+# Return a datum which is compatible to the test schema.
+#
+# @param deep [Hash{Symbol => String}] a different deep hash to embed
 # @return [Hash{String => Mixed}] the datum
 def avro_data(deep = nil)
-  deep ||= { test: 'true', fancy: 'data' }
-  Rimless.avro_sanitize(name: 'test',
-                        include: {
-                          id: 'uuid-v4'
-                        },
-                        deep: deep)
+  Rimless.avro_sanitize(avro_data_symbol_keys(deep))
 end


### PR DESCRIPTION
* Added the `Rimless.encode` (`.avro_encode`) and `Rimless.decode`
  (`.avro_decode`) helpers/shortcuts to simplify the interaction with the
  Apache Avro library
  * The `.encode` method automatically performs input data sanitation and
    supports deep relative (to the local namespace) schema resolution. This
    allows you to access deeply located schemes relative by just providing a
    leading period (eg. `.deep.a.b.c` becomes
    `development.your_app.deep.a.b.c`)
* The `.message`, '.sync_message', '.async_message' helpers now make use of the
  new `.encode` functionality which adds transparent data sanitation and schema
  name features
* At the `test` environment the compiled Avro schemas output path is not
  deleted anymore, instead the compiled schemas are overwritten. This may keep
  dead schemas, but it allows parallel test execution without flaws. The removal
  of the compiled schema directory caused previously file read errors when a
  parallel process started a recompilation.     