### PR TITLE
Added support for the parallel_tests gem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 0.2.1
+
+* Added support for the
+  [parallel_tests](https://github.com/grosser/parallel_tests) gem and
+  reconfigure the compiled schema directory to be unique per running test
+  thread.  This fixes all race conditions which slow down or break user test
+  suites.
+
 ### 0.2.0
 
 * Added the `Rimless.encode` (`.avro_encode`) and `Rimless.decode`

--- a/lib/rimless/rspec.rb
+++ b/lib/rimless/rspec.rb
@@ -36,6 +36,18 @@ RSPEC_CONFIGURER.configure do |config|
       .to_rack(FakeConfluentSchemaRegistryServer)
     # Clear any cached data
     FakeConfluentSchemaRegistryServer.clear
+
+    # This allows parallel test execution without race conditions on the
+    # compiled Apache Avro schemas.  So when each test have its own compiled
+    # schema repository it cannot conflict while refreshing it.
+    unless ENV['TEST_ENV_NUMBER'].nil?
+      Rimless.configure do |conf|
+        conf.compiled_avro_schema_path = conf.compiled_avro_schema_path.join(
+          "test-worker-#{ENV['TEST_ENV_NUMBER']}"
+        )
+      end
+    end
+
     # Reconfigure the Rimless AvroTurf instance
     Rimless.configure_avro_turf
   end


### PR DESCRIPTION
This update ships a workaround for parallel test execution which was
slowed down or broken due to race conditions on the compiled Apache Avro
schema file repository. Before this update all test workers (threads)
shared the very same file repository which causes race conditions when
one worker performs a refresh and another is trying to lookup schema
definitions. This was fixed with a file repository separation per test
worker.

Signed-off-by: Hermann Mayer <hermann.mayer92@gmail.com>