### PR TITLE
Mock waterdrop producers in RSpec tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### next
+
+* Mocked WaterDrop producers in the rimless rspec helper so that tests
+  won't actually talk to Kafka (#9)
+
 ### 1.0.3
 
 * Corrected broken stats when no consumer is yet defined (#8)

--- a/lib/rimless/rspec.rb
+++ b/lib/rimless/rspec.rb
@@ -62,6 +62,10 @@ RSPEC_CONFIGURER.configure do |config|
     # Clear any cached data
     FakeConfluentSchemaRegistryServer.clear
 
+    # Do not interact with Apache Kafka itself on tests
+    allow(WaterDrop::AsyncProducer).to receive(:call)
+    allow(WaterDrop::SyncProducer).to receive(:call)
+
     # Reconfigure the Rimless AvroTurf instance
     Rimless.configure_avro_turf
 


### PR DESCRIPTION
Mocks the WaterDrop Karafka message producers so that RSpec tests don't actually try to interact with Kafka. To be released in 1.0.4.