### PR TITLE
Fix Karafka interchanger issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### next
+
+* Added support for Karafka `~> 1.4.0` and set is as minimum dependency version
+  (#10)
+
 ### 1.0.4
 
 * Mocked WaterDrop producers in the rimless rspec helper so that tests

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,11 @@ update: install
 	@$(MKDIR) -p $(VENDOR_DIR)
 	@$(call run-shell,$(BUNDLE) exec $(APPRAISAL) update)
 
-test: #install
+test: \
+	test-specs \
+	test-style
+
+test-specs:
 	# Run the whole test suite
 	@$(call run-shell,$(BUNDLE) exec $(RAKE))
 

--- a/lib/rimless/consumer.rb
+++ b/lib/rimless/consumer.rb
@@ -131,7 +131,7 @@ module Rimless
                 topic(topic_name) do
                   consumer dest_consumer
                   worker Rimless::ConsumerJob
-                  interchanger Rimless::Karafka::Base64Interchanger
+                  interchanger Rimless::Karafka::Base64Interchanger.new
                 end
               end
             end

--- a/lib/rimless/karafka/avro_deserializer.rb
+++ b/lib/rimless/karafka/avro_deserializer.rb
@@ -6,15 +6,19 @@ module Rimless
     class AvroDeserializer
       # Deserialize an Apache Avro encoded Apache Kafka message.
       #
-      # @param message [String] the binary blob to deserialize
+      # @param params [Karafka::Params::Params] the Karafka message parameters
       # @return [Hash{Symbol => Mixed}] the deserialized Apache Avro message
-      def call(message)
+      def call(params)
+        # When the Kafka message does not have a payload, we won't fail.
+        # This is for Kafka users which use log compaction with a nil payload.
+        return if params.raw_payload.nil?
+
         # We use sparsed hashes inside of Apache Avro messages for schema-less
         # blobs of data, such as loosely structured metadata blobs.  Thats a
         # somewhat bad idea on strictly typed and defined messages, but their
         # occurence should be rare.
         Rimless
-          .decode(message.payload)
+          .decode(params.raw_payload)
           .yield_self { |data| Sparsify(data, sparse_array: true) }
           .yield_self { |data| data.transform_keys { |key| key.delete('\\') } }
           .yield_self { |data| Unsparsify(data, sparse_array: true) }

--- a/lib/rimless/karafka/base64_interchanger.rb
+++ b/lib/rimless/karafka/base64_interchanger.rb
@@ -7,14 +7,14 @@ module Rimless
     #
     # rubocop:disable Security/MarshalLoad because we encode/decode the
     #   messages in our own controlled context
-    class Base64Interchanger
+    class Base64Interchanger < ::Karafka::Interchanger
       # Encode a binary Apache Kafka message(s) so they can be passed to the
       # Sidekiq +Rimless::ConsumerJob+.
       #
       # @param params_batch [Mixed] the raw message(s) to encode
       # @return [String] the marshaled+base64 encoded data
-      def self.encode(params_batch)
-        Base64.encode64(Marshal.dump(params_batch.to_a))
+      def encode(params_batch)
+        Base64.encode64(Marshal.dump(super))
       end
 
       # Decode the binary Apache Kafka message(s) so they can be processed by
@@ -22,8 +22,8 @@ module Rimless
       #
       # @param params_string [String] the marshaled+base64 encoded data
       # @return [Mixed] the unmarshaled+base64 decoded data
-      def self.decode(params_string)
-        Marshal.load(Base64.decode64(params_string))
+      def decode(params_string)
+        Marshal.load(Base64.decode64(super)).map(&:stringify_keys)
       end
     end
     # rubocop:enable Security/MarshalLoad

--- a/rimless.gemspec
+++ b/rimless.gemspec
@@ -25,9 +25,9 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activesupport', '>= 4.2.0'
   spec.add_runtime_dependency 'avro_turf', '~> 0.11.0'
-  spec.add_runtime_dependency 'karafka', '~> 1.3'
-  spec.add_runtime_dependency 'karafka-sidekiq-backend', '~> 1.3'
-  spec.add_runtime_dependency 'karafka-testing', '~> 1.3'
+  spec.add_runtime_dependency 'karafka', '~> 1.4'
+  spec.add_runtime_dependency 'karafka-sidekiq-backend', '~> 1.4'
+  spec.add_runtime_dependency 'karafka-testing', '~> 1.4'
   spec.add_runtime_dependency 'sinatra'
   spec.add_runtime_dependency 'sparsify', '~> 1.1'
   spec.add_runtime_dependency 'waterdrop', '~> 1.2'

--- a/spec/rimless/consumer_spec.rb
+++ b/spec/rimless/consumer_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Rimless::Consumer do
 
       it 'configures the first topic interchanger correctly' do
         expect(topics.first.interchanger).to \
-          be(Rimless::Karafka::Base64Interchanger)
+          be_a(Rimless::Karafka::Base64Interchanger)
       end
 
       it 'configures the second topic name correctly' do
@@ -85,7 +85,7 @@ RSpec.describe Rimless::Consumer do
 
       it 'configures the second topic interchanger correctly' do
         expect(topics.last.interchanger).to \
-          be(Rimless::Karafka::Base64Interchanger)
+          be_a(Rimless::Karafka::Base64Interchanger)
       end
     end
 


### PR DESCRIPTION
Unfortunately, [the default interchanger from Karafka](https://github.com/karafka/sidekiq-backend/blob/2376aefb63cf4c5fe5feebcc792e975f5819bbde/lib/karafka/interchanger.rb) changed, and Rimless implemented a copy of the previous implementation. Just like the readme states. This breaks the regular runtime when the versions match `~> 1.4.0` with this error, at every new Kafka message which hits the Sidekiq consumer job:

```
NoMethodError: undefined method `fetch' for #<Karafka::Params::Params:0x0000000007208648>
[GEM_ROOT]/gems/karafka-sidekiq-backend-1.4.0/lib/karafka/extensions/params_builder.rb:14 :in `from_hash`
[GEM_ROOT]/gems/karafka-sidekiq-backend-1.4.0/lib/karafka/extensions/params_batch_builder.rb:14 :in `block in from_array`
[GEM_ROOT]/gems/karafka-sidekiq-backend-1.4.0/lib/karafka/extensions/params_batch_builder.rb:13 :in `map`
[GEM_ROOT]/gems/karafka-sidekiq-backend-1.4.0/lib/karafka/extensions/params_batch_builder.rb:13 :in `from_array`
[GEM_ROOT]/gems/karafka-sidekiq-backend-1.4.0/lib/karafka/base_worker.rb:51 :in `consumer`
[GEM_ROOT]/gems/karafka-sidekiq-backend-1.4.0/lib/karafka/base_worker.rb:31 :in `perform`
```

This pull request fixes the issue while converting the custom Base64 interchanger from a class with all-static methods to a regular instanced class. This allows us under the hood to inherit the default interchanger and use it first to be compatible with upstream changes.

See: 
* https://app.honeybadger.io/projects/59456/faults/68863959
* https://github.com/karafka/sidekiq-backend/issues/74
