### PR TITLE
Fixed broken Ruby 2.5 support.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,3 +65,9 @@ RSpec/FilePath:
 # Because we just implemented the ActiveRecord API.
 Rails/SkipsModelValidations:
   Enabled: false
+
+# Because Rubocop does not respect the `TargetRubyVersion: 2.5` for this cop,
+# so it converts to `then` which is not yet available on Ruby 2.5 which causes
+# `NoMethodError` errors. NOTE: Remove when Ruby 2.5 support is dropped.
+Style/ObjectThen:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### next
 
-* TODO: Replace this bullet point with an actual description of a change.
+* Reverted to use `yield_self` instead of `then` in order to support Ruby 2.5
+  as advertised (broken since #19, 1.3.0) (#31)
 
 ### 1.4.1
 

--- a/lib/rimless/karafka/avro_deserializer.rb
+++ b/lib/rimless/karafka/avro_deserializer.rb
@@ -19,9 +19,9 @@ module Rimless
         # occurence should be rare.
         Rimless
           .decode(params.raw_payload)
-          .then { |data| Sparsify(data, sparse_array: true) }
-          .then { |data| data.transform_keys { |key| key.delete('\\') } }
-          .then { |data| Unsparsify(data, sparse_array: true) }
+          .yield_self { |data| Sparsify(data, sparse_array: true) }
+          .yield_self { |data| data.transform_keys { |key| key.delete('\\') } }
+          .yield_self { |data| Unsparsify(data, sparse_array: true) }
           .deep_symbolize_keys
       end
     end

--- a/spec/rimless/karafka/avro_deserializer_spec.rb
+++ b/spec/rimless/karafka/avro_deserializer_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# rubocop:disable RSpec/MultipleMemoizedHelpers because of various
+#   testing contexts
+RSpec.describe Rimless::Karafka::AvroDeserializer do
+  let(:instance) { described_class.new }
+  let(:params) { Karafka::Params::Params.new(raw_payload, metadata) }
+  let(:raw_payload) { nil }
+  let(:metadata) { Karafka::Params::Metadata }
+  let(:blob) do
+    Rimless.avro.encode({ 'id' => 'uuid' }, schema_name: 'include')
+  end
+
+  describe '#call' do
+    let(:action) { instance.call(params) }
+
+    context 'without raw payload' do
+      it 'returns nil' do
+        expect(action).to be_nil
+      end
+    end
+
+    context 'with raw payload' do
+      let(:raw_payload) { blob }
+
+      it 'returns a hash' do
+        expect(action).to be_a(Hash)
+      end
+
+      it 'returns a hash with symbol keys' do
+        expect(action.keys).to all(be_a(Symbol))
+      end
+
+      it 'returns the correctly decoded hash' do
+        expect(action).to be_eql(id: 'uuid')
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
On a Ruby 2.5 application:

```
Job: Rimless::ConsumerJob
Error Class: NoMethodError
Error Message: undefined method `then' for #<Hash:0x00007fb5053b6200>
Error Backtrace: /app/vendor/bundle/ruby/2.5.0/gems/rimless-1.4.0/lib/rimless/karafka/avro_deserializer.rb:22:in `call'
```