### PR TITLE
Disabled the logger extension for the development environment by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### next
 
-* TODO: Replace this bullet point with an actual description of a change.
+* Do not extend the `Rimless.logger` to write to stdout by default when running
+  in the `development` environment - this generates duplicated messages when
+  the configured logger already writes to stdout. A new configuration was added
+  `Rimless.configuration.extend_dev_logger = false` was added (#32)
 
 ### 1.4.2
 

--- a/lib/rimless/configuration.rb
+++ b/lib/rimless/configuration.rb
@@ -27,6 +27,10 @@ module Rimless
       Logger.new($stdout)
     end
 
+    # Whenever the logger should be extended to write to stdout when
+    # running in development environment (Rimless.env)
+    config_accessor(:extend_dev_logger) { false }
+
     # At least one broker of the Apache Kafka cluster
     config_accessor(:kafka_brokers) do
       ENV.fetch('KAFKA_BROKERS', 'kafka://message-bus.local:9092').split(',')

--- a/lib/rimless/consumer.rb
+++ b/lib/rimless/consumer.rb
@@ -88,6 +88,10 @@ module Rimless
       # When we run in development mode, we want to write the logs
       # to file and to stdout.
       def initialize_logger!
+        # Skip when configured not to extend the logger
+        return unless Rimless.configuration.extend_dev_logger
+
+        # Skip when not in development environment or in the server process
         return unless Rimless.env.development? && server?
 
         $stdout.sync = true


### PR DESCRIPTION
Do not extend the `Rimless.logger` to write to stdout by default when running
  in the `development` environment - this generates duplicated messages when
  the configured logger already writes to stdout. A new configuration was added
  `Rimless.configuration.extend_dev_logger = false` was added