### PR TITLE
Improved the validation of compiled schema files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### next
 
+* Moved the schema file validation into the retry block for parallel execution
+  (#36)
 * Updated the [Kafka Playground](./doc/kafka-playground) to the latest
   Apache Kafka (3.7) and Schema Registry (7.6) versions (#35)
 

--- a/lib/rimless/avro_utils.rb
+++ b/lib/rimless/avro_utils.rb
@@ -41,10 +41,9 @@ module Rimless
         FileUtils.mkdir_p(File.dirname(dest))
         # Write the rendered file contents to the destination
         File.write(dest, ERB.new(File.read(src)).result(binding))
+        # Check the written file for correct JSON
+        validate_file(dest)
       end
-
-      # Check the written file for correct JSON
-      validate_file(dest)
     end
 
     # Check the given file for valid JSON.


### PR DESCRIPTION
```
Errno::ENOENT: No such file or directory @ rb_sysopen - /app/config/avro_schemas/compiled/development/[...].avsc
/usr/local/bundle/gems/rimless-1.5.1/lib/rimless/avro_utils.rb:57:in `validate_file'
/usr/local/bundle/gems/rimless-1.5.1/lib/rimless/avro_utils.rb:47:in `render_file'
/usr/local/bundle/gems/rimless-1.5.1/lib/rimless/avro_utils.rb:26:in `block in recompile_schemas'
/usr/local/bundle/gems/rimless-1.5.1/lib/rimless/avro_utils.rb:26:in `each'
/usr/local/bundle/gems/rimless-1.5.1/lib/rimless/avro_utils.rb:26:in `recompile_schemas'
/usr/local/bundle/gems/rimless-1.5.1/lib/rimless/dependencies.rb:63:in `configure_avro_turf'
/usr/local/bundle/gems/rimless-1.5.1/lib/rimless/dependencies.rb:16:in `configure_dependencies'
/usr/local/bundle/gems/rimless-1.5.1/lib/rimless/railtie.rb:22:in `block in <class:Railtie>'
/usr/local/bundle/gems/activesupport-5.2.8.1/lib/active_support/lazy_load_hooks.rb:69:in `block in execute_hook'
```