### PR TITLE
Corrected the Sidekiq interchanger decoding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### next
 
-* TODO: Replace this bullet point with an actual description of a change.
+* Corrected the Sidekiq interchanger decoding, which is caused by an upstream
+  update of the karafka-sidekiq-backend gem (#43)
 
 ### 1.7.6
 

--- a/lib/rimless/karafka/base64_interchanger.rb
+++ b/lib/rimless/karafka/base64_interchanger.rb
@@ -11,7 +11,8 @@ module Rimless
       # Encode a binary Apache Kafka message(s) so they can be passed to the
       # Sidekiq +Rimless::ConsumerJob+.
       #
-      # @param params_batch [Mixed] the raw message(s) to encode
+      # @param params_batch [Karafka::Params::ParamsBatch] the karafka params
+      #   batch object
       # @return [String] the marshaled+base64 encoded data
       def encode(params_batch)
         Base64.encode64(Marshal.dump(super))
@@ -21,9 +22,9 @@ module Rimless
       # the Sidekiq +Rimless::ConsumerJob+.
       #
       # @param params_string [String] the marshaled+base64 encoded data
-      # @return [Mixed] the unmarshaled+base64 decoded data
-      def decode(params_string)
-        Marshal.load(Base64.decode64(super)).map(&:stringify_keys)
+      # @return [Array<Hash>] the unmarshaled+base64 decoded data
+      def decode(params_batch)
+        super(Marshal.load(Base64.decode64(params_batch))).map(&:stringify_keys)
       end
     end
     # rubocop:enable Security/MarshalLoad


### PR DESCRIPTION
This patch fixes our bad decoding on the Base64 interchanger with a recent [karafka-sidekiq-backend gem](https://github.com/karafka/sidekiq-backend/blob/master/lib/karafka/interchanger.rb) version (>= 1.4.4).

Root cause: we put our encoded data into the `#decode` method of the base interchanger class, and then decoded it from a base64+marshalled string. This is our fault as it must be done the other way around. (First decode the base64+marshalled string and then put it into the base decoding method)

This was never an issue until the `#decode` method of the base interchanger class was extended from a simple pass-through to an actual implementation which expects `Array<Hash>` as first argument.

`#decode` method of the base interchanger class: [Before](https://github.com/karafka/sidekiq-backend/blob/2376aefb63cf4c5fe5feebcc792e975f5819bbde/lib/karafka/interchanger.rb#L26-L28) /  [After](https://github.com/karafka/sidekiq-backend/blob/master/lib/karafka/interchanger.rb#L36-L46)

---

Sidekiq Params:

```
[
  "leads-api-canary_canary.payment-api.payments",
  "BAhbBnsHSSIQcmF[...]",
  {
    "batch_size": 1,
    "first_offset": 4787,
    "highwater_mark_offset": 4788,
    "last_offset": 4787,
    "offset_lag": 0,
    "partition": 0,
    "topic": "canary.payment-api.payments",
    "unknown_last_offset": false
  }
]
```

Sidekiq error:

```
Error Class	NoMethodError
Error Message	undefined method `map' for #<String:0x000055f6104a8b78> Did you mean? tap
Error Backtrace	/usr/local/bundle/gems/karafka-sidekiq-backend-1.4.9/lib/karafka/interchanger.rb:37:in `decode'
/usr/local/bundle/gems/rimless-1.7.6/lib/rimless/karafka/base64_interchanger.rb:26:in `decode'
/usr/local/bundle/gems/karafka-sidekiq-backend-1.4.9/lib/karafka/base_worker.rb:53:in `consumer'
/usr/local/bundle/gems/karafka-sidekiq-backend-1.4.9/lib/karafka/base_worker.rb:32:in `perform'
/usr/local/bundle/gems/sidekiq-6.4.2/lib/sidekiq/processor.rb:196:in `execute_job'
/usr/local/bundle/gems/sidekiq-6.4.2/lib/sidekiq/processor.rb:164:in `block (2 levels) in process'
/usr/local/bundle/gems/sidekiq-6.4.2/lib/sidekiq/middleware/chain.rb:138:in `block in invoke'
/usr/local/bundle/gems/sidekiq-history-0.0.12/lib/sidekiq/history/middleware.rb:54:in `call'
/usr/local/bundle/gems/sidekiq-6.4.2/lib/sidekiq/middleware/chain.rb:140:in `block in invoke'
```