### PR TITLE
Added support for Sidekiq 7 in conjunction with Rails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### next
 
-* TODO: Replace this bullet point with an actual description of a change.
+* Added support for Sidekiq 7 in conjunction with Rails (#52)
 
 ### 1.12.0 (27 February 2025)
 

--- a/lib/rimless/consumer.rb
+++ b/lib/rimless/consumer.rb
@@ -48,6 +48,16 @@ module Rimless
 
         ENV['RAILS_ENV'] ||= 'development'
         ENV['KARAFKA_ENV'] = ENV.fetch('RAILS_ENV', nil)
+
+        # This is relevant for Karafka server processes, as the +karafka.rb+
+        # root file just requires +rimless+ and then we require
+        # +karafka-sidekiq-backend+ which in fact requires +sidekiq+ before
+        # +rails+ was required. We cannot change the order here, but we can
+        # explicitly load the Sidekiq/Rails integration as we know at this
+        # point that we should load Rails and we're going to use Sidekiq, too.
+        # See: https://bit.ly/3D8ZHj3
+        require 'sidekiq/rails'
+
         require rails_env
         Rails.application.eager_load!
       end


### PR DESCRIPTION
See: https://github.com/hausgold/painless/pull/131, https://github.com/hausgold/env/issues/305

Otherwise we run into the following error:

```
bundler: failed to load command: karafka (/usr/local/bundle/bin/karafka)
/usr/local/bundle/gems/sidekiq-7.3.9/lib/active_job/queue_adapters/sidekiq_adapter.rb:71:in
`<class:SidekiqAdapter>': uninitialized constant Sidekiq::ActiveJob (NameError)
	from /usr/local/bundle/gems/sidekiq-7.3.9/lib/active_job/queue_adapters/sidekiq_adapter.rb:13:in `<module:QueueAdapters>'
	from /usr/local/bundle/gems/sidekiq-7.3.9/lib/active_job/queue_adapters/sidekiq_adapter.rb:4:in `<module:ActiveJob>'
	from /usr/local/bundle/gems/sidekiq-7.3.9/lib/active_job/queue_adapters/sidekiq_adapter.rb:3:in `<main>'
	from /usr/local/bundle/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in `require'
	from /usr/local/bundle/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in `require'
	from /usr/local/bundle/gems/bootsnap-1.18.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /usr/local/bundle/gems/activejob-6.1.7.10/lib/active_job/queue_adapters.rb:137:in `const_get'
	from /usr/local/bundle/gems/activejob-6.1.7.10/lib/active_job/queue_adapters.rb:137:in `lookup'
	from /usr/local/bundle/gems/activejob-6.1.7.10/lib/active_job/queue_adapter.rb:40:in `queue_adapter='
	from /usr/local/bundle/gems/activejob-6.1.7.10/lib/active_job/railtie.rb:30:in `block (3 levels) in <class:Railtie>'
	from /usr/local/bundle/gems/activejob-6.1.7.10/lib/active_job/railtie.rb:28:in `each'
	from /usr/local/bundle/gems/activejob-6.1.7.10/lib/active_job/railtie.rb:28:in `block (2 levels) in <class:Railtie>'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/lazy_load_hooks.rb:71:in `class_eval'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/lazy_load_hooks.rb:71:in `block in execute_hook'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/lazy_load_hooks.rb:61:in `with_execution_control'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/lazy_load_hooks.rb:66:in `execute_hook'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/lazy_load_hooks.rb:43:in `block in on_load'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/lazy_load_hooks.rb:42:in `each'
	from /usr/local/bundle/gems/activesupport-6.1.7.10/lib/active_support/lazy_load_hooks.rb:42:in `on_load'
	from /usr/local/bundle/gems/activejob-6.1.7.10/lib/active_job/railtie.rb:27:in `block in <class:Railtie>'
	from /usr/local/bundle/gems/railties-6.1.7.10/lib/rails/initializable.rb:32:in `instance_exec'
	from /usr/local/bundle/gems/railties-6.1.7.10/lib/rails/initializable.rb:32:in `run'
	from /usr/local/bundle/gems/railties-6.1.7.10/lib/rails/initializable.rb:61:in `block in run_initializers'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:228:in `block in tsort_each'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:431:in `each_strongly_connected_component_from'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:349:in `block in each_strongly_connected_component'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:347:in `each'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:347:in `call'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:347:in `each_strongly_connected_component'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:226:in `tsort_each'
	from /usr/local/lib/ruby/2.7.0/tsort.rb:205:in `tsort_each'
	from /usr/local/bundle/gems/railties-6.1.7.10/lib/rails/initializable.rb:60:in `run_initializers'
	from /usr/local/bundle/gems/railties-6.1.7.10/lib/rails/application.rb:391:in `initialize!'
	from /app/config/environment.rb:7:in `<top (required)>'
	from /usr/local/bundle/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in `require'
	from /usr/local/bundle/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in `require'
	from /usr/local/bundle/gems/rimless-1.12.0/lib/rimless/consumer.rb:51:in `initialize_rails!'
	from /usr/local/bundle/gems/rimless-1.12.0/lib/rimless/consumer.rb:22:in `initialize!'
	from /usr/local/bundle/gems/rimless-1.12.0/lib/rimless/consumer.rb:202:in `consumer'
	from /app/karafka.rb:6:in `<top (required)>'
	from /usr/local/bundle/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in `require'
	from /usr/local/bundle/gems/zeitwerk-2.6.18/lib/zeitwerk/kernel.rb:34:in `require'
	from /usr/local/bundle/gems/karafka-1.4.14/bin/karafka:8:in `<top (required)>'
	from /usr/local/bundle/bin/karafka:25:in `load'
	from /usr/local/bundle/bin/karafka:25:in `<top (required)>'
	from /usr/local/bundle/gems/bundler-2.3.27/lib/bundler/cli/exec.rb:58:in `load'
	from /usr/local/bundle/gems/bundler-2.3.27/lib/bundler/cli/exec.rb:58:in `kernel_load'
	from /usr/local/bundle/gems/bundler-2.3.27/lib/bundler/cli/exec.rb:23:in `run'
	from /usr/local/bundle/gems/bundler-2.3.27/lib/bundler/cli.rb:486:in `exec'
	from /usr/local/bundle/gems/bundler-2.3.27/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /usr/local/bundle/gems/bundler-2.3.27/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /usr/local/bundle/gems/bundler-2.3.27/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /usr/local/bundle/gems/bundler-2.3.27/lib/bundler/cli.rb:31:in `dispatch'
	from /usr/local/bundle/gems/bundler-2.3.27/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /usr/local/bundle/gems/bundler-2.3.27/lib/bundler/cli.rb:25:in `start'
	from /usr/local/bundle/gems/bundler-2.3.27/exe/bundle:48:in `block in <top (required)>'
	from /usr/local/bundle/gems/bundler-2.3.27/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
	from /usr/local/bundle/gems/bundler-2.3.27/exe/bundle:36:in `<top (required)>'
	from /usr/local/bundle/bin/bundle:25:in `load'
	from /usr/local/bundle/bin/bundle:25:in `<main>'
```