### PR TITLE
Load the railtie when initializing rails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### next
 
 * Upgraded the rubocop dependencies (#53)
+* Make sure to load 'rimless/railtie' when we initialize Rails on the consumer
+  application (#54)
 
 ### 1.13.0 (27 February 2025)
 

--- a/lib/rimless/consumer.rb
+++ b/lib/rimless/consumer.rb
@@ -59,6 +59,7 @@ module Rimless
         require 'sidekiq/rails'
 
         require rails_env
+        require 'rimless/rails'
         Rails.application.eager_load!
       end
 


### PR DESCRIPTION
See: https://github.com/hausgold/notification-distributor-processor/pull/374

---

This patch ensures that the `rimless/railtie` is properly loaded on the Karafka server/consumer application. The boot order looks like this:

* `$ karafka server`
* [`require 'karafka'`](https://github.com/karafka/karafka/blob/1.4-stable/bin/karafka#L3)
  * [`require 'rimless'`](https://github.com/hausgold/rimless/blob/master/lib/rimless/tasks/templates/karafka.rb#L3)
  * [`require 'rimless/railtie' if defined? Rails`](https://github.com/hausgold/rimless/blob/master/lib/rimless.rb#L45) - this check fails, as Rails is not yet loaded
  * [`Rimless.consumer`](https://github.com/hausgold/rimless/blob/master/lib/rimless/tasks/templates/karafka.rb#L6)
  * [`Rimless::ConsumerApp.initialize!`](https://github.com/hausgold/rimless/blob/master/lib/rimless/consumer.rb#L212)
  * [`initialize_rails!`](https://github.com/hausgold/rimless/blob/master/lib/rimless/consumer.rb#L40)
  * [`require '/app/config/environment.rb'`](https://github.com/hausgold/rimless/blob/master/lib/rimless/consumer.rb#L61)
  * [`Rails.application.eager_load!`](https://github.com/hausgold/rimless/blob/master/lib/rimless/consumer.rb#L62)
  * Now Rails is loaded and initialized, but the `rimless/railtie` is not loaded, thats where this PR kicks in
* [`require Karafka.boot_file.to_s`](https://github.com/karafka/karafka/blob/1.4-stable/bin/karafka#L8) (`/app/karafka.rb`)
* [`Karafka::Cli.start`](https://github.com/karafka/karafka/blob/1.4-stable/bin/karafka#L8)
* [`Karafka::Server.run`](https://github.com/karafka/karafka/blob/1.4-stable/lib/karafka/cli/server.rb#L34)
* [`Karafka::App.config.internal.fetcher.call`](https://github.com/karafka/karafka/blob/1.4-stable/lib/karafka/server.rb#L53)
* [`Thread.new { Karafka::Connection::Listener.new(consumer_group).call }`](https://github.com/karafka/karafka/blob/1.4-stable/lib/karafka/fetcher.rb#L17)
* [`Client.new(@consumer_group).fetch_loop`](https://github.com/Jack12816/karafka/blob/1.4-stable/lib/karafka/connection/listener.rb#L39)
* [`kafka_consumer.each_batch(**settings)`](https://github.com/Jack12816/karafka/blob/1.4-stable/lib/karafka/connection/client.rb#L36)
* [`MessageDelegator.call(@consumer_group.id, raw_data)`](https://github.com/Jack12816/karafka/blob/1.4-stable/lib/karafka/connection/listener.rb#L44)
* [`consumer.call`](https://github.com/Jack12816/karafka/blob/1.4-stable/lib/karafka/connection/message_delegator.rb#L30)

